### PR TITLE
Changed layout dimensions on Thumbnail settings

### DIFF
--- a/src/TournamentStreamHelper.py
+++ b/src/TournamentStreamHelper.py
@@ -237,6 +237,7 @@ class Window(QMainWindow):
         toggleWidgets.addAction(tournamentInfo.toggleViewAction())
         toggleWidgets.addAction(self.scoreboard.toggleViewAction())
         toggleWidgets.addAction(commentary.toggleViewAction())
+        toggleWidgets.addAction(thumbnailSetting.toggleViewAction())
 
         self.gameSelect = QComboBox()
         self.gameSelect.setEditable(True)

--- a/src/layout/TSHThumbnailSettings.ui
+++ b/src/layout/TSHThumbnailSettings.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>854</width>
+    <width>962</width>
     <height>753</height>
    </rect>
   </property>
@@ -16,7 +16,7 @@
   <widget class="QLabel" name="thumbnailPreview">
    <property name="geometry">
     <rect>
-     <x>340</x>
+     <x>380</x>
      <y>40</y>
      <width>640</width>
      <height>360</height>
@@ -35,7 +35,7 @@
   <widget class="QLabel" name="label">
    <property name="geometry">
     <rect>
-     <x>320</x>
+     <x>380</x>
      <y>10</y>
      <width>101</width>
      <height>31</height>
@@ -50,7 +50,7 @@
     <rect>
      <x>10</x>
      <y>10</y>
-     <width>301</width>
+     <width>361</width>
      <height>481</height>
     </rect>
    </property>
@@ -62,8 +62,8 @@
      <rect>
       <x>0</x>
       <y>0</y>
-      <width>282</width>
-      <height>631</height>
+      <width>338</width>
+      <height>678</height>
      </rect>
     </property>
     <layout class="QVBoxLayout" name="verticalLayout_6">


### PR DESCRIPTION
- Repositioned elements on the Thumbnail settings tab in order to not need horizontal scrolling on the sidebar (Issue mentionned in https://github.com/joaorb64/TournamentStreamHelper/pull/64)

![Screenshot_694](https://user-images.githubusercontent.com/1964201/160937453-26c3741d-a8d0-4423-9c2e-b06ac53b3bac.png)

- Added Thumbnail Settings tab to Widget Display menu